### PR TITLE
Fix unsupported characters ń (Issue #46) for "vsts-tfvc-checkin" task.

### DIFF
--- a/vsts-tfvc-checkin/TfvcCheckin.ps1
+++ b/vsts-tfvc-checkin/TfvcCheckin.ps1
@@ -260,7 +260,7 @@ Try
             if (($override -eq $null) -or $OverridePolicy)
             {
                 $checkInParameters = new-object Microsoft.TeamFoundation.VersionControl.Client.WorkspaceCheckInParameters(@($pendingChanges), $Comment)
-                $checkinParameters.Author = $env:BUILD_QUEUEDBY
+                $checkinParameters.Author = $env:BUILD_QUEUEDBYID
                 if ($CheckinNotes -ne $null)
                 {
                     $checkInParameters.CheckinNotes = $CheckinNotes


### PR DESCRIPTION
  * There have been issues with in TFVC 2017 user names containing ", " characters.
  * Solved using "$checkinParameters.Author = $env:BUILD_QUEUEDBYID" instead of "$env:BUILD_QUEUEDBY" build variable.